### PR TITLE
setup.py packages include corrected

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,5 @@ setup(
     url="https://github.com/chinokenochkan/torch-metrics",
     author="Chi Nok Enoch Kan @chinokenochkan",
     author_email="kanxx030@gmail.com",
-    packages=["torch_metrics"],
+    packages=find_packages(include=["torch_metrics", "torch_metrics.*"]),
 )


### PR DESCRIPTION
All submodules are now included.

Test made with `pip install -i https://test.pypi.org/simple/ torch-metrics-corrected==1.1.7`

This is now working:
`from torch_metrics.classification import Accuracy`